### PR TITLE
Append instead of override DefaultExcludesInProjectFolder

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -37,7 +37,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- WARNING: This pattern is there to ignore folders such as .git and .vs, but it will also match items included with a
          relative path outside the project folder (for example "..\Shared\Shared.cs").  So be sure only to apply it to items
          that are in the project folder. -->
-    <DefaultExcludesInProjectFolder>$(DefaultItemExcludesInProjectFolder);**/.*/**</DefaultExcludesInProjectFolder>
+    <DefaultExcludesInProjectFolder>$(DefaultExcludesInProjectFolder);**/.*/**</DefaultExcludesInProjectFolder>
 
   </PropertyGroup>
 


### PR DESCRIPTION
According to this [documentation](https://docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#defaultexcludesinprojectfolder) the following should work to exclude items:
```xml
<PropertyGroup>
  <DefaultExcludesInProjectFolder>$(DefaultExcludesInProjectFolder);**/myprefix*/**</DefaultExcludesInProjectFolder>
</PropertyGroup>
```

however Microsoft.NET.Sdk.DefaultItems.targets includes the following lines which overrides the already set value for `DefaultExcludesInProjectFolder`:
```xml
<DefaultExcludesInProjectFolder>$(DefaultItemExcludesInProjectFolder);**/.*/**</DefaultExcludesInProjectFolder>
```

It looks like the issue is that when the property name was changed from `DefaultItemExcludesInProjectFolder` to `DefaultExcludesInProjectFolder` in #806 the property used for the concatenation was not likewise updated.
